### PR TITLE
Add draggable tabbed toolbar to Explorer band

### DIFF
--- a/AddressBar/AddressBar.h
+++ b/AddressBar/AddressBar.h
@@ -1,88 +1,262 @@
 #pragma once
 
-#ifndef _ADDRESSBAR_H
-#define _ADDRESSBAR_H
-
 #include "stdafx.h"
 #include "framework.h"
 #include "resource.h"
 #include "ClassicExplorer_i.h"
 #include "dllmain.h"
 #include "util/util.h"
-#include <string>
+
+#include <shlobj.h>
+#include <shlwapi.h>
+#include <shellapi.h>
+#include <vector>
+#include <array>
+#include <memory>
+
+class CAddressBar;
+
+class ExplorerTabDropTarget : public IDropTarget
+{
+public:
+        explicit ExplorerTabDropTarget(CAddressBar *owner);
+
+        // IUnknown
+        IFACEMETHODIMP QueryInterface(REFIID riid, void **ppvObject) override;
+        ULONG STDMETHODCALLTYPE AddRef() override;
+        ULONG STDMETHODCALLTYPE Release() override;
+
+        // IDropTarget
+        IFACEMETHODIMP DragEnter(IDataObject *pDataObject, DWORD grfKeyState, POINTL pt, DWORD *pdwEffect) override;
+        IFACEMETHODIMP DragOver(DWORD grfKeyState, POINTL pt, DWORD *pdwEffect) override;
+        IFACEMETHODIMP DragLeave() override;
+        IFACEMETHODIMP Drop(IDataObject *pDataObject, DWORD grfKeyState, POINTL pt, DWORD *pdwEffect) override;
+
+private:
+        ~ExplorerTabDropTarget() = default;
+
+        LONG m_refCount = 1;
+        CAddressBar *m_owner = nullptr;
+        CComPtr<IDataObject> m_currentDataObject;
+};
 
 class CAddressBar : public CWindowImpl<CAddressBar>
 {
-	protected: // Class members:
-		CWindow m_toolbar = NULL;
-		CComPtr<IShellBrowser> m_pShellBrowser = NULL;
+private:
+        struct UniquePidl
+        {
+                PIDLIST_ABSOLUTE pidl = nullptr;
 
-		HWND m_goButton = NULL;
-		HWND m_comboBox = NULL;
-		HWND m_comboBoxEditCtl = NULL;
+                UniquePidl() = default;
+                explicit UniquePidl(PIDLIST_ABSOLUTE source)
+                {
+                        reset(source);
+                }
 
-		bool m_showGoButton = false;
+                UniquePidl(const UniquePidl &other)
+                {
+                        if (other.pidl)
+                                pidl = ILCloneFull(other.pidl);
+                }
 
-		HIMAGELIST m_himlGoInactive = NULL;
-		HIMAGELIST m_himlGoActive = NULL;
+                UniquePidl(UniquePidl &&other) noexcept
+                {
+                        pidl = other.pidl;
+                        other.pidl = nullptr;
+                }
 
-		WCHAR m_displayName[1024] = { 0 };
-		WCHAR m_currentPath[1024] = { 0 };
-		bool m_locationHasPhysicalPath = false;
-		static std::wstring m_goText;
-		ClassicExplorerTheme m_theme;
+                UniquePidl &operator=(const UniquePidl &other)
+                {
+                        if (this != &other)
+                        {
+                                reset(other.pidl);
+                        }
+                        return *this;
+                }
 
-		// This Internet Explorer API is also compatible with File Explorer, and
-		// provides useful events.
-		CComPtr<IWebBrowser2> m_pWebBrowser = NULL;
+                UniquePidl &operator=(UniquePidl &&other) noexcept
+                {
+                        if (this != &other)
+                        {
+                                reset();
+                                pidl = other.pidl;
+                                other.pidl = nullptr;
+                        }
+                        return *this;
+                }
 
-		friend class CAddressBarHostBand;
+                ~UniquePidl()
+                {
+                        reset();
+                }
 
-	public: // Window setup:
-		DECLARE_WND_CLASS(L"ClassicExplorer.AddressBar")
+                void reset(PIDLIST_ABSOLUTE source = nullptr)
+                {
+                        if (pidl)
+                        {
+                                CoTaskMemFree(pidl);
+                                pidl = nullptr;
+                        }
+                        if (source)
+                        {
+                                pidl = ILCloneFull(source);
+                        }
+                }
+        };
 
-		BEGIN_MSG_MAP(AddressBar)
-			NOTIFY_CODE_HANDLER(NM_CLICK, OnComponentNotifyClick)
-			MESSAGE_HANDLER(WM_CREATE, OnCreate)
-			MESSAGE_HANDLER(WM_DESTROY, OnDestroy)
-			MESSAGE_HANDLER(WM_NOTIFY, OnNotify)
-		END_MSG_MAP()
+        struct Tab
+        {
+                UniquePidl pidl;
+                std::wstring title;
+                RECT bounds = {0};
+                bool active = false;
+        };
 
-	public: // Exported functions:
+        struct TabGroup
+        {
+                std::wstring name;
+                COLORREF color = RGB(180, 200, 235);
+                std::vector<Tab> tabs;
+                RECT bounds = {0};
+        };
 
-		HWND GetToolbar(void)
-		{
-			return m_toolbar.m_hWnd;
-		}
+        struct HitTestResult
+        {
+                bool valid = false;
+                bool groupHandle = false;
+                int groupIndex = -1;
+                int tabIndex = -1;
+        };
 
-		void SetBrowsers(CComPtr<IShellBrowser> pShellBrowser, CComPtr<IWebBrowser2> pWebBrowser);
+public:
+        DECLARE_WND_CLASS(L"ClassicExplorer.TabBar")
 
-		HRESULT InitComboBox();
-		HRESULT HandleNavigate();
-		HRESULT RefreshCurrentAddress();
-		BOOL GetCurrentAddressText(CComHeapPtr<WCHAR> &pszText);
-		HRESULT STDMETHODCALLTYPE ShowFileNotFoundError(HRESULT hRet);
-		HRESULT Execute();
+        BEGIN_MSG_MAP(CAddressBar)
+                MESSAGE_HANDLER(WM_CREATE, OnCreate)
+                MESSAGE_HANDLER(WM_DESTROY, OnDestroy)
+                MESSAGE_HANDLER(WM_PAINT, OnPaint)
+                MESSAGE_HANDLER(WM_ERASEBKGND, OnEraseBackground)
+                MESSAGE_HANDLER(WM_SIZE, OnSize)
+                MESSAGE_HANDLER(WM_LBUTTONDOWN, OnLButtonDown)
+                MESSAGE_HANDLER(WM_LBUTTONUP, OnLButtonUp)
+                MESSAGE_HANDLER(WM_MOUSEMOVE, OnMouseMove)
+                MESSAGE_HANDLER(WM_CONTEXTMENU, OnContextMenu)
+                MESSAGE_HANDLER(WM_CAPTURECHANGED, OnCaptureChanged)
+        END_MSG_MAP()
 
-	protected: // Message handlers:
-		LRESULT OnComponentNotifyClick(WPARAM wParam, LPNMHDR notifyHeader, BOOL &bHandled);
-		LRESULT OnCreate(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
-		LRESULT OnDestroy(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
-		LRESULT OnNotify(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
+        HWND GetToolbar() const { return m_hWnd; }
 
-	protected: // Miscellaneous functions:
+        void SetBrowsers(CComPtr<IShellBrowser> pShellBrowser, CComPtr<IWebBrowser2> pWebBrowser);
+        HRESULT InitializeTabs();
+        void OnExplorerNavigate();
+        SIZE GetDesiredSize() const;
 
-		static LRESULT CALLBACK ComboboxSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, UINT_PTR uIdSubclass, DWORD_PTR dwRefData);
-		static LRESULT CALLBACK RealComboboxSubclassProc(HWND hWnd, UINT uMsg, WPARAM wParam, LPARAM lParam, UINT_PTR uIdSubclass, DWORD_PTR dwRefData);
+        void HandleExternalDragEnter(DWORD keyState, POINTL pt, IDataObject *pDataObject);
+        void HandleExternalDragOver(DWORD keyState, POINTL pt);
+        void HandleExternalDragLeave();
+        void HandleExternalDrop(IDataObject *dataObject, DWORD keyState, POINTL pt);
+        bool CanAcceptDataObject(IDataObject *dataObject) const;
 
-		LRESULT CreateGoButton();
+private:
+        // message handlers
+        LRESULT OnCreate(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
+        LRESULT OnDestroy(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
+        LRESULT OnPaint(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
+        LRESULT OnEraseBackground(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
+        LRESULT OnSize(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
+        LRESULT OnLButtonDown(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
+        LRESULT OnLButtonUp(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
+        LRESULT OnMouseMove(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
+        LRESULT OnContextMenu(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
+        LRESULT OnCaptureChanged(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL &bHandled);
 
-		HRESULT GetCurrentFolderPidl(PIDLIST_ABSOLUTE *pidl);
-		HRESULT GetCurrentFolderName(WCHAR *pszName, long length);
-		LRESULT GetBooleanRegKey(PTCHAR key, bool* boolValue);
+        // layout helpers
+        void LoadSettings();
+        void EnsureDefaultGroup();
+        void LayoutTabs();
+        void LayoutTabsIfNeeded();
+        int CalculateTabWidth(HDC hdc, const std::wstring &text) const;
+        void RefreshActiveState();
 
-		HRESULT ParseAddress(PIDLIST_RELATIVE *pidlOut);
-		HRESULT ExecuteCommandLine();
+        // painting helpers
+        void DrawBackground(HDC hdc, const RECT &clientRect) const;
+        void DrawGroup(HDC hdc, const TabGroup &group) const;
+        void DrawTab(HDC hdc, const Tab &tab, COLORREF groupColor) const;
+        void DrawGroupHandle(HDC hdc, const TabGroup &group) const;
+        void DrawGhost(HDC hdc) const;
+        void DrawDropHover(HDC hdc) const;
+        static COLORREF AdjustColor(COLORREF color, double factor);
+
+        // tab management
+        HRESULT AddTabForLocation(PIDLIST_ABSOLUTE pidl, bool makeActive, bool navigate, COLORREF colorOverride = RGB(180, 200, 235));
+        void RemoveEmptyGroups();
+        void ActivateTab(int groupIndex, int tabIndex, bool navigate);
+        void ActivateTabByPidl(PIDLIST_ABSOLUTE pidl);
+        void UpdateActiveTabFromExplorer();
+        void CreateNewWindowForTab(const Tab &tab);
+        std::wstring GetTabFilesystemPath(const Tab &tab) const;
+        void SetGroupColor(int groupIndex, COLORREF color);
+        void ShowGroupColorMenu(int groupIndex, POINT screenPoint);
+        void ShowContextMenuForTab(int groupIndex, int tabIndex, POINT screenPoint);
+        void EnsureGhostRect(const POINT &pt);
+        void UpdatePendingDropTarget(const POINT &pt);
+        void UpdateDropHover(const POINT &pt);
+
+        // drag helpers
+        HitTestResult HitTest(const POINT &pt) const;
+        void StartTabDrag(int groupIndex, int tabIndex, const POINT &pt);
+        void StartGroupDrag(int groupIndex, const POINT &pt);
+        void UpdateDrag(const POINT &pt);
+        void CommitDrag(const POINT &pt);
+        void CancelDrag();
+        void DetachDraggedTab();
+        void ReorderTab(int targetGroup, int targetIndex);
+        void ReorderGroup(int targetIndex);
+
+        // drop helpers
+        std::vector<std::wstring> ExtractFilePathsFromDataObject(IDataObject *dataObject) const;
+        HRESULT PerformFileOperation(const std::vector<std::wstring> &sourcePaths, const std::wstring &targetFolder, bool move) const;
+
+private:
+        CComPtr<IShellBrowser> m_pShellBrowser = nullptr;
+        CComPtr<IWebBrowser2> m_pWebBrowser = nullptr;
+        CComPtr<ExplorerTabDropTarget> m_dropTarget;
+
+        std::vector<TabGroup> m_groups;
+        bool m_layoutDirty = true;
+        bool m_autoSizeTabs = true;
+        SIZE m_fixedTabSize = {180, 32};
+        int m_tabPaddingX = 14;
+        int m_tabPaddingY = 6;
+        int m_tabSpacing = 6;
+        int m_groupSpacing = 14;
+        int m_groupHandleWidth = 8;
+        int m_tabMargin = 6;
+        int m_rowSpacing = 6;
+        int m_minTabWidth = 120;
+        int m_maxTabWidth = 280;
+        int m_maxRows = 10;
+        int m_activeGroup = 0;
+        int m_activeTab = 0;
+        int m_totalHeight = 0;
+
+        bool m_draggingTab = false;
+        bool m_draggingGroup = false;
+        bool m_dragClickCandidate = false;
+        bool m_detachPending = false;
+        POINT m_dragStart = {0};
+        POINT m_dragPoint = {0};
+        RECT m_dragGhostRect = {0};
+        bool m_showGhost = false;
+        int m_draggedGroupIndex = -1;
+        int m_draggedTabIndex = -1;
+        int m_pendingDropGroup = -1;
+        int m_pendingDropTab = -1;
+
+        int m_dropHoverGroup = -1;
+        int m_dropHoverTab = -1;
+
+        COLORREF m_backgroundColor = RGB(245, 246, 247);
+        COLORREF m_borderColor = RGB(160, 160, 160);
 };
 
-#endif // _ADDRESSBAR_H

--- a/AddressBar/AddressBarHostBand.h
+++ b/AddressBar/AddressBarHostBand.h
@@ -22,16 +22,10 @@ class ATL_NO_VTABLE CAddressBarHostBand :
 	protected: // Class members:
 		IInputObjectSite *m_pSite = NULL;
 		HWND m_parentWindow = NULL;
-		CAddressBar m_addressBar;
-		CComPtr<IWebBrowser2> m_pWebBrowser = NULL;
-		static std::wstring m_addressText;
+                CAddressBar m_addressBar;
+                CComPtr<IWebBrowser2> m_pWebBrowser = NULL;
 
-		friend class CAddressBar;
-
-	protected: // Internal methods:
-		WCHAR GetAddressAccelerator();
-
-	public: // COM class setup:
+        public: // COM class setup:
 		DECLARE_REGISTRY_RESOURCEID_V2_WITHOUT_MODULE(IDR_CLASSICEXPLORER, CAddressBarHostBand)
 
 		BEGIN_SINK_MAP(CAddressBarHostBand)
@@ -59,7 +53,7 @@ class ATL_NO_VTABLE CAddressBarHostBand :
 	public: // COM method implementations:
 		
 		// implement IDeskBand:
-		STDMETHOD(GetBandInfo)(DWORD dwBandId, DWORD dwViewMode, DESKBANDINFO *pDbi);
+                STDMETHOD(GetBandInfo)(DWORD dwBandId, DWORD dwViewMode, DESKBANDINFO *pDbi);
 
 		// implement IObjectWithSite:
 		STDMETHOD(SetSite)(IUnknown *pUnkSite);

--- a/BrandBand/BrandBand.cpp
+++ b/BrandBand/BrandBand.cpp
@@ -105,9 +105,53 @@ LRESULT CBrandBand::OnClick(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHand
 
 	AppendMenuW(hMenu, MF_SEPARATOR, 0, 0);
 
-	AppendMenuW(hMenu, (currentSettings.showGoButton ? MF_CHECKED : MF_UNCHECKED) | MF_STRING, 7010, L"Show Go button");
-	AppendMenuW(hMenu, (currentSettings.showAddressLabel ? MF_CHECKED : MF_UNCHECKED) | MF_STRING, 7011, L"Show Address label");
-	AppendMenuW(hMenu, (currentSettings.showFullAddress ? MF_CHECKED : MF_UNCHECKED) | MF_STRING, 7012, L"Show full address");
+        AppendMenuW(hMenu, (currentSettings.showGoButton ? MF_CHECKED : MF_UNCHECKED) | MF_STRING, 7010, L"Show Go button");
+        AppendMenuW(hMenu, (currentSettings.showAddressLabel ? MF_CHECKED : MF_UNCHECKED) | MF_STRING, 7011, L"Show Address label");
+        AppendMenuW(hMenu, (currentSettings.showFullAddress ? MF_CHECKED : MF_UNCHECKED) | MF_STRING, 7012, L"Show full address");
+
+        AppendMenuW(hMenu, MF_SEPARATOR, 0, 0);
+
+        AppendMenuW(hMenu, (currentSettings.tabAutoSize ? MF_CHECKED : MF_UNCHECKED) | MF_STRING, 7020, L"Auto size tabs");
+
+        HMENU hFixedWidthMenu = CreatePopupMenu();
+        const struct
+        {
+                UINT id;
+                LONG width;
+                const wchar_t *label;
+        } widthOptions[] = {
+                {7021, 140, L"140 px"},
+                {7022, 180, L"180 px"},
+                {7023, 220, L"220 px"}
+        };
+        for (const auto &option : widthOptions)
+        {
+                UINT flags = MF_STRING;
+                if (!currentSettings.tabAutoSize && currentSettings.tabFixedWidth == option.width)
+                        flags |= MF_CHECKED;
+                AppendMenuW(hFixedWidthMenu, flags, option.id, option.label);
+        }
+        AppendMenuW(hMenu, MF_POPUP | MF_STRING, (UINT_PTR)hFixedWidthMenu, L"Fixed tab width");
+
+        HMENU hFixedHeightMenu = CreatePopupMenu();
+        const struct
+        {
+                UINT id;
+                LONG height;
+                const wchar_t *label;
+        } heightOptions[] = {
+                {7024, 28, L"28 px"},
+                {7025, 32, L"32 px"},
+                {7026, 36, L"36 px"}
+        };
+        for (const auto &option : heightOptions)
+        {
+                UINT flags = MF_STRING;
+                if (currentSettings.tabFixedHeight == option.height)
+                        flags |= MF_CHECKED;
+                AppendMenuW(hFixedHeightMenu, flags, option.id, option.label);
+        }
+        AppendMenuW(hMenu, MF_POPUP | MF_STRING, (UINT_PTR)hFixedHeightMenu, L"Fixed tab height");
 
 	POINT p;
 	p.x = GET_X_LPARAM(lParam);
@@ -121,10 +165,10 @@ LRESULT CBrandBand::OnClick(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHand
 
 	if(sel == 0) // Current theme selected, or outside click, nothing changes
 		return S_OK;
-	switch (sel)
-	{
-	case 7000:
-		CEUtil::WriteCESettings(CEUtil::CESettings(CLASSIC_EXPLORER_2K, -1, -1,-1));
+        switch (sel)
+        {
+        case 7000:
+                CEUtil::WriteCESettings(CEUtil::CESettings(CLASSIC_EXPLORER_2K, -1, -1,-1));
 		break;
 	case 7001:
 		CEUtil::WriteCESettings(CEUtil::CESettings(CLASSIC_EXPLORER_XP, -1, -1,-1));
@@ -141,10 +185,60 @@ LRESULT CBrandBand::OnClick(UINT uMsg, WPARAM wParam, LPARAM lParam, BOOL& bHand
 	case 7011:
 		CEUtil::WriteCESettings(CEUtil::CESettings(CLASSIC_EXPLORER_NONE, -1, !currentSettings.showAddressLabel, -1));
 		break;
-	case 7012:
-		CEUtil::WriteCESettings(CEUtil::CESettings(CLASSIC_EXPLORER_NONE, -1, -1, !currentSettings.showFullAddress));
-		break;
-	}
+        case 7012:
+                CEUtil::WriteCESettings(CEUtil::CESettings(CLASSIC_EXPLORER_NONE, -1, -1, !currentSettings.showFullAddress));
+                break;
+        case 7020:
+                CEUtil::WriteCESettings(CEUtil::CESettings(
+                        CLASSIC_EXPLORER_NONE,
+                        -1,
+                        -1,
+                        -1,
+                        currentSettings.tabAutoSize ? 0 : 1,
+                        currentSettings.tabFixedWidth,
+                        currentSettings.tabFixedHeight));
+                break;
+        case 7021:
+        case 7022:
+        case 7023:
+        {
+                LONG targetWidth = 180;
+                if (sel == 7021)
+                        targetWidth = 140;
+                else if (sel == 7023)
+                        targetWidth = 220;
+
+                CEUtil::WriteCESettings(CEUtil::CESettings(
+                        CLASSIC_EXPLORER_NONE,
+                        -1,
+                        -1,
+                        -1,
+                        0,
+                        targetWidth,
+                        currentSettings.tabFixedHeight));
+                break;
+        }
+        case 7024:
+        case 7025:
+        case 7026:
+        {
+                LONG targetHeight = 32;
+                if (sel == 7024)
+                        targetHeight = 28;
+                else if (sel == 7026)
+                        targetHeight = 36;
+
+                CEUtil::WriteCESettings(CEUtil::CESettings(
+                        CLASSIC_EXPLORER_NONE,
+                        -1,
+                        -1,
+                        -1,
+                        currentSettings.tabAutoSize,
+                        currentSettings.tabFixedWidth,
+                        targetHeight));
+                break;
+        }
+        }
 	MessageBeep(0);
 	MessageBox(L"Open a new file explorer window to see the changes.");
 	return S_OK;

--- a/addressbar.vcxproj
+++ b/addressbar.vcxproj
@@ -120,7 +120,7 @@
       <SubSystem>Windows</SubSystem>
       <ModuleDefinitionFile>.\ClassicExplorer.def</ModuleDefinitionFile>
       <RegisterOutput>true</RegisterOutput>
-      <AdditionalDependencies>comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comctl32.lib;shlwapi.lib;shell32.lib;msimg32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -221,7 +221,7 @@
       <EnableCOMDATFolding>true</EnableCOMDATFolding>
       <OptimizeReferences>true</OptimizeReferences>
       <RegisterOutput>true</RegisterOutput>
-      <AdditionalDependencies>comctl32.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>comctl32.lib;shlwapi.lib;shell32.lib;msimg32.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/util/util.h
+++ b/util/util.h
@@ -19,21 +19,36 @@ enum ClassicExplorerTheme
 
 namespace CEUtil
 {
-	struct CESettings
-	{
-		ClassicExplorerTheme theme = CLASSIC_EXPLORER_NONE;
-		DWORD showGoButton = -1;
-		DWORD showAddressLabel = -1;
-		DWORD showFullAddress = -1;
+        struct CESettings
+        {
+                ClassicExplorerTheme theme = CLASSIC_EXPLORER_NONE;
+                LONG showGoButton = -1;
+                LONG showAddressLabel = -1;
+                LONG showFullAddress = -1;
+                LONG tabAutoSize = -1;
+                LONG tabFixedWidth = -1;
+                LONG tabFixedHeight = -1;
 
-		CESettings(ClassicExplorerTheme t, int a, int b, int f)
-		{
-			theme = t;
-			showGoButton = a;
-			showAddressLabel = b;
-			showFullAddress = f;
-		}
-	};
+                CESettings() = default;
+
+                CESettings(
+                        ClassicExplorerTheme t,
+                        LONG showGo,
+                        LONG showLabel,
+                        LONG showFull,
+                        LONG autoSize = -1,
+                        LONG fixedWidth = -1,
+                        LONG fixedHeight = -1)
+                {
+                        theme = t;
+                        showGoButton = showGo;
+                        showAddressLabel = showLabel;
+                        showFullAddress = showFull;
+                        tabAutoSize = autoSize;
+                        tabFixedWidth = fixedWidth;
+                        tabFixedHeight = fixedHeight;
+                }
+        };
 	CESettings GetCESettings();
 	void WriteCESettings(CESettings& toWrite);
 	HRESULT GetCurrentFolderPidl(CComPtr<IShellBrowser> pShellBrowser, PIDLIST_ABSOLUTE *pidlOut);


### PR DESCRIPTION
## Summary
- replace the legacy address bar implementation with a custom multi-row Explorer tab toolbar that supports drag-and-drop reordering, detachable tabs, and translucent drag feedback
- add tab grouping capabilities with color-coded islands, group handle dragging, and configurable auto-sized or fixed-size tabs persisted in new registry settings and surfaced in the brand band menu
- wire the new toolbar into Explorer navigation events, enable drop-to-copy/move file operations on tabs, and update project dependencies for the new UI features

## Testing
- Not run (Windows-targeted project)


------
https://chatgpt.com/codex/tasks/task_e_68d6f6fec9a48330ad0f245b2c77b66a